### PR TITLE
Fix download link

### DIFF
--- a/include/resto/Routes/RestoRouteGET.php
+++ b/include/resto/Routes/RestoRouteGET.php
@@ -403,7 +403,7 @@ class RestoRouteGET extends RestoRoute {
          * Download feature then exit
          */
         else if ($segments[3] === 'download') {
-            return $this->GET_featureDownload();
+            return $this->GET_featureDownload($collection, $feature);
         }
 
         /*

--- a/include/resto/Utils/RestoFeatureUtil.php
+++ b/include/resto/Utils/RestoFeatureUtil.php
@@ -94,7 +94,7 @@ class RestoFeatureUtil {
      */
     private function toProperties($rawCorrectedArray) {
         
-        $thisUrl = isset($this->collection) ? RestoUtil::restoUrl($this->collection->getUrl(), $rawCorrectedArray['identifier']) : RestoUtil::restoUrl($this->context->baseUrl, '/collections/' . $rawCorrectedArray['collection'] . '/' . $rawCorrectedArray['identifier']);
+        $thisUrl = isset($this->collection) ? RestoUtil::restoUrl($this->collection->getUrl(), '/' . $rawCorrectedArray['identifier']) : RestoUtil::restoUrl($this->context->baseUrl, '/collections/' . $rawCorrectedArray['collection'] . '/' . $rawCorrectedArray['identifier']);
         
         $properties = $rawCorrectedArray;
         


### PR DESCRIPTION
The download link is missing a '/' between the collection name and the feature identifier (same problem for feature links)

When calling the download link manually I get a null pointer exception due to missing parameters when calling GET_featureDownload method.